### PR TITLE
Added ability to limit the LoadBalancers picked up by chisel-operator

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://fyralabs.com/funding.json

--- a/charts/chisel-operator/templates/deployment.yaml
+++ b/charts/chisel-operator/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: "REQUIRE_OPERATOR_CLASS"
+              value: "{{.Values.global.requireOperatorClass}}"
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/chisel-operator/values.yaml
+++ b/charts/chisel-operator/values.yaml
@@ -7,6 +7,11 @@ replicaCount: 1 # Right now only 1 replica is supported
 # For now, we recommend running only 1 replica else Chisel Operator may constantly
 # recreate resources, wasting your API resources and costing you money.
 
+# Add the ability to limit to just the chisel opertator LoadBalancerClass
+# Set requireOperatorClass: true to limit the LoadBalancers picked up by chisel-operator
+global:
+  requireOperatorClass: false
+
 image:
   repository: ghcr.io/fyralabs/chisel-operator
   pullPolicy: IfNotPresent

--- a/site/public/.well-known/funding-manifest-urls
+++ b/site/public/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://fyralabs.com/funding.json

--- a/src/cloud/aws.rs
+++ b/src/cloud/aws.rs
@@ -270,7 +270,10 @@ impl Provisioner for AWSProvisioner {
         } else {
             warn!("No status found for exit node, creating new instance");
             // TODO: this should be handled by the controller logic
-            return self.create_exit_node(auth, exit_node).await.map(|(status, _)| status);
+            return self
+                .create_exit_node(auth, exit_node)
+                .await
+                .map(|(status, _)| status);
         }
     }
 

--- a/src/cloud/linode.rs
+++ b/src/cloud/linode.rs
@@ -179,7 +179,10 @@ impl Provisioner for LinodeProvisioner {
             Ok(status)
         } else {
             warn!("No instance status found, creating new instance");
-            return self.create_exit_node(auth.clone(), exit_node).await.map(|(status, _)| status);
+            return self
+                .create_exit_node(auth.clone(), exit_node)
+                .await
+                .map(|(status, _)| status);
         }
     }
 }

--- a/src/cloud/mod.rs
+++ b/src/cloud/mod.rs
@@ -27,7 +27,8 @@ pub trait Provisioner {
         &self,
         auth: Secret,
         exit_node: ExitNode,
-    ) -> color_eyre::Result<ExitNodeStatus>;
+        // Should return the pointer to the password secret for the exit node
+    ) -> color_eyre::Result<(ExitNodeStatus, Secret)>;
     async fn update_exit_node(
         &self,
         auth: Secret,

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -16,10 +16,6 @@
    There can also be a case where the user creates an exit node manually,
    with the provisioner annotation set, in that case chisel operator will
    create a cloud resource for that exit node and manages it.
-
-   todo: properly handle all this logic
-
-   todo: use `tracing` and put every operation in a span to make debugging easier
 */
 
 use color_eyre::Result;
@@ -210,7 +206,7 @@ async fn select_exit_node_local(
                     .unwrap_or(false);
 
                 // Is the ExitNode not cloud provisioned or is the status set?
-                !is_cloud_provisioned || node.status.is_some()
+                (!is_cloud_provisioned || node.status.is_some()) && !node.is_assigned()
             })
             .collect::<Vec<ExitNode>>()
             .first()
@@ -613,7 +609,6 @@ async fn reconcile_nodes(obj: Arc<ExitNode>, ctx: Arc<Context>) -> Result<Action
                 {
                     Event::Apply(node) => {
                         let _node = {
-
                             let mut pass_secret: Option<k8s_openapi::api::core::v1::Secret> = None;
                             // if status exists, update, else create
                             let cloud_resource = if let Some(_status) = node.status.as_ref() {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -42,6 +42,8 @@ use std::{collections::BTreeMap, sync::Arc};
 use std::time::Duration;
 use tracing::{debug, error, info, instrument, warn};
 
+use std::env;
+
 use crate::{
     cloud::Provisioner,
     ops::{
@@ -301,6 +303,13 @@ async fn exit_node_for_service(
 async fn reconcile_svcs(obj: Arc<Service>, ctx: Arc<Context>) -> Result<Action, ReconcileError> {
     // Return if service is not LoadBalancer or if the loadBalancerClass is not blank or set to $OPERATOR_CLASS
 
+    // Check if the REQUIRE_OPERATOR_CLASS environment variable is set
+    let limit_load_balancer_class;
+    match env::var("REQUIRE_OPERATOR_CLASS") {
+        Ok(v) => limit_load_balancer_class = v,
+        Err(_e) => limit_load_balancer_class = "false".to_string(),
+    }
+
     // todo: is there anything different need to be done for OpenShift? We use vanilla k8s and k3s/rke2 so we don't know
     if obj
         .spec
@@ -311,7 +320,7 @@ async fn reconcile_svcs(obj: Arc<Service>, ctx: Arc<Context>) -> Result<Action, 
             .spec
             .as_ref()
             .filter(|spec| {
-                spec.load_balancer_class.is_none()
+                (spec.load_balancer_class.is_none() && ( limit_load_balancer_class == "false"))
                     || spec.load_balancer_class == Some(OPERATOR_CLASS.to_string())
             })
             .is_none()

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -128,7 +128,27 @@ impl ExitNode {
 
         Ok(secret)
     }
+
+    /// Checks if the exit node is already assigned to a service
+    pub fn is_assigned(&self) -> bool {
+        self.metadata
+            .annotations
+            .as_ref()
+            .map(|annotations| annotations.contains_key(EXIT_NODE_NAME_LABEL))
+            .unwrap_or(false)
+    }
+
+    /// Gets the IP address of the exit node
+    pub fn get_ip(&self) -> Option<String> {
+        self.status.as_ref().map(|status| status.ip.clone())
+    }
+
+    /// Gets the name of the exit node
+    pub fn get_name(&self) -> Option<String> {
+        self.metadata.name.clone()
+    }
 }
+
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 pub struct ExitNodeStatus {
     pub provider: String,

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -88,6 +88,7 @@ impl ExitNode {
     ///
     /// Generates a new secret with the `auth` key containing the auth string for chisel in the same namespace as the ExitNode
     pub async fn generate_secret(&self, password: String) -> Result<Secret> {
+        debug!("Generating secret for ExitNode");
         let secret_name = self.get_secret_name();
 
         let auth_tmpl = format!("{}:{}", crate::cloud::pwgen::DEFAULT_USERNAME, password);


### PR DESCRIPTION
Configured this locally and noticed @xyhhx has created a request for the capability - https://github.com/FyraLabs/chisel-operator/issues/150

Uses an environment variable REQUIRE_OPERATOR_CLASS to determine whether the LoadBalancers picked up by chisel-operator should be limited.

Includes configuration updates for the helm chart

