### PR TITLE
feat: support loadBalancerClass-scoped service handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,22 @@ helm install chisel-operator oci://ghcr.io/fyralabs/chisel-operator/chisel-opera
 
 ## Usage
 
+### Restricting reconciliation to a LoadBalancer class
+
+By default the operator watches every Kubernetes service of type `LoadBalancer`. If you only want it to manage services that target a specific [`loadBalancerClass`](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class), set the `LOAD_BALANCER_CLASS` environment variable (or the `loadBalancerClass` Helm value) to the class name you want the operator to handle. Only services whose `spec.loadBalancerClass` matches that string will be reconciled; other services will be ignored.
+
+When deploying a filtered operator you must also add the same `loadBalancerClass` to each Service you expect it to control:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami
+spec:
+  type: LoadBalancer
+  loadBalancerClass: my.chisel.class
+```
+
 ### Operator-managed exit nodes
 
 This operator can automatically provision exit nodes on cloud providers.

--- a/charts/chisel-operator/templates/deployment.yaml
+++ b/charts/chisel-operator/templates/deployment.yaml
@@ -30,6 +30,11 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.loadBalancerClass }}
+          env:
+            - name: LOAD_BALANCER_CLASS
+              value: {{ . | quote }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
 
@@ -45,4 +50,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-

--- a/charts/chisel-operator/values.yaml
+++ b/charts/chisel-operator/values.yaml
@@ -47,5 +47,9 @@ tolerations: []
 
 affinity: {}
 
+# Optional load balancer class handled by the operator. When empty, all LoadBalancer
+# services are reconciled, matching the default behavior.
+loadBalancerClass: ""
+
 # Create CRDs for Chisel Operator
 createCrds: true

--- a/site/src/content/docs/guides/exposing-a-service.md
+++ b/site/src/content/docs/guides/exposing-a-service.md
@@ -26,6 +26,30 @@ spec:
 As you can see, the type of this service is `LoadBalancer`, which is required for chisel-operator to pick up on the service.
 Note that Chisel Operator acts on all LoadBalancer services in the cluster by default.
 
+## Limiting reconciliation to a LoadBalancer class
+
+If you only want the operator to manage services that opt in to a specific load balancer class, you can set the `LOAD_BALANCER_CLASS` environment variable (or the `loadBalancerClass` Helm value) when deploying it.
+Once the operator is running with that filter, only services whose `spec.loadBalancerClass` matches the configured class name will be reconciled; other services are ignored.
+
+To opt a service in, add the same `loadBalancerClass` to the Service spec:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: whoami
+spec:
+  type: LoadBalancer
+  loadBalancerClass: my.chisel.class
+  selector:
+    app: whoami
+  ports:
+    - port: 80
+      targetPort: 80
+```
+
+Leaving the value empty (or omitting the field) continues to expose the service through any unfiltered operator instance.
+
 Additionally, there's also a commented out annotation, `chisel-operator.io/exit-node-name`.
 By default, Chisel Operator will automatically select a random, unused `ExitNode` on the cluster if a cloud provisioner or exit node annotation is not set.
 If you'd like to force the service to a particular exit node, you can uncomment out the annotation, setting it to the name of the `ExitNode` to target.

--- a/site/src/content/docs/guides/installation.md
+++ b/site/src/content/docs/guides/installation.md
@@ -32,4 +32,12 @@ You can configure the helm chart values by creating a `values.yaml` file and pas
 helm install chisel-operator oci://ghcr.io/fyralabs/chisel-operator/chisel-operator -f values.yaml
 ```
 
+For example, to limit reconciliation to services that declare a custom load balancer class, set the `loadBalancerClass` value to the class name you want the operator to handle:
+
+```yaml
+loadBalancerClass: my.chisel.class
+```
+
+Make sure every Service you expect the operator to manage sets the same value in `spec.loadBalancerClass`.
+
 See [the Helm chart directory](https://github.com/FyraLabs/chisel-operator/tree/main/charts/chisel-operator) for more information on the Helm chart.


### PR DESCRIPTION
Disclaimer! The rust code was basically completely AI written, since I have no clue about Rust. If you don't like specific implementation details then please go ahead and push changes directly, thanks.

I did an end-2-end test run on my Kubernetes Cluster, and the changes work fine. No more conflicts with my MetalLB LoadBalancer! :tada:

---
I wasn't able to build the docker image due to a glibc version mismatch in the build stage (`rust:latest`) and the run stage (`redhat/ubi9-micro:latest`). This is most likely that `rust:latest` now uses debian trixie which ships which a much newer version than `redhat/ubi9` uses.

I purpose that we just switch the run stage to trixie as well. Additionally I made the container rootless :)

This is now similar [how Vaultwarden Docker is built](https://github.com/dani-garcia/vaultwarden/blob/main/docker/Dockerfile.debian).

Sidenote: I tried switching to ubi9 in the build stage, but this isn't that simple and redhat is like 5 rust versions behind. So I don't think it worth it.

---

Closes #153 
Fixes #150