### PR TITLE
fix(helm-chart): remove always empty `name` label

### DIFF
--- a/charts/chisel-operator/templates/deployment.yaml
+++ b/charts/chisel-operator/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "chisel-operator.fullname" . }}
   labels:
-    name: {{- include "chisel-operator.labels" . | nindent 4 }}
+    {{- include "chisel-operator.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount}}
   selector:


### PR DESCRIPTION
This commit removes the `name` label from the deployment which is currently always empty.

Also in my case it is breaking the deployment via Argo CD by causing the following error: "failed to set app instance tracking info on manifest: failed to set app instance label: failed to get labels from target object apps/v1, Kind=Deployment /chisel-operator: .metadata.labels accessor error: contains non-string value in the map under key "name": <nil> is of the type <nil>, expected string"